### PR TITLE
Check type of private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ You have to provide a baseurl for your FRITZ!Box, a username, a password, and a 
 | password  | `FRITZBOX_PASSWORD` | `-p`                |
 | certpath  | `FRITZBOX_CERTPATH` | `-c`                |
 
+## Limitations
+
+Only RSA keys are [supported by FRITZ!OS](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7590/1525_Importing-your-own-certificate-to-the-FRITZ-Box/).
+
 ## Examples
 
 Using command line options:

--- a/fritzbox_upload_certificate.sh
+++ b/fritzbox_upload_certificate.sh
@@ -109,6 +109,10 @@ if [ ! -r "${certpath}/fullchain.pem" ] || [ ! -r "${certpath}/privkey.pem" ]; t
   error "Certpath ${certpath} must contain fullchain.pem and privkey.pem"
 fi
 
+if ! grep -q -- "-BEGIN RSA PRIVATE KEY-" "${certpath}/privkey.pem"; then
+  error "FRITZ!OS only supports RSA private keys."
+fi
+
 request_file="$(mktemp -t XXXXXX)"
 trap 'rm -f "${request_file}"' EXIT
 


### PR DESCRIPTION
Only RSA keys are supported by FRITZ!OS.

Issue found by @hafx: https://github.com/franzs/fritzbox_upload_certificate/issues/13