### PR TITLE
Add FRITZ!Repeater 1200 AX with 7.57 as unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ export FRITZBOX_CERTPATH=./certificates/fritz.box
 | FRITZ!Box 7530 AX         | 7.57     | ✓      |
 | FRITZ!Box 7580            | 7.30     | ✓      |
 | FRITZ!Box 7590            | 7.29     | ✓      |
+| FRITZ!Repeater 1200 AX    | 7.57     | ✕      |
 | FRITZ!WLAN Repeater DVB-C | 7.01     | ✓      |
 
 Let me know what your results are.


### PR DESCRIPTION
Reported by mbo77 via
https://gist.github.com/wikrie/f1d5747a714e0a34d0582981f7cb4cfb?permalink_comment_id=4697208#gistcomment-4697208