### PR TITLE
Remove RSA key type check

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For debugging set the environment variable `FRITZBOX_DEBUG` to any non-empty str
 
 ## Limitations
 
-Only RSA keys are [supported by FRITZ!OS](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7590/1525_Importing-your-own-certificate-to-the-FRITZ-Box/).
+Older Fritz!OS versions support RSA keys only. Newer versions support EC keys, too. EC key support was confirmed with Fritz!OS version 8.25. If a certificate cannot be imported, it is worth checking the key type.
 
 ## Examples
 

--- a/fritzbox_upload_certificate.sh
+++ b/fritzbox_upload_certificate.sh
@@ -137,10 +137,6 @@ if [ ! -r "${fullchain}" ] || [ ! -r "${privkey}" ]; then
   error "Certpath ${certpath} must contain fullchain.pem and privkey.pem"
 fi
 
-if ! ${OPENSSL_CMD} rsa -in "${privkey}" -check -noout &>/dev/null; then
-  error "FRITZ!OS only supports RSA private keys."
-fi
-
 if [ -n "${debug}" ]; then
   debug_output="$(mktemp "${tmp_dir}/fritzbox_debug.XXXXXX")"
 
@@ -207,5 +203,5 @@ EOD
 ${CURL_CMD} "${curl_opts[@]}" -X POST "${baseurl}/cgi-bin/firmwarecfg" -H "Content-type: multipart/form-data boundary=${boundary}" --data-binary "@${request_file}" | process_curl_output | grep -qE "${SUCCESS_MESSAGES}"
 # shellcheck disable=SC2181
 if [ $? -ne 0 ]; then
-  error "Could not import certificate."
+  error "Could not import certificate. Maybe an unsupported key type was used. Older Fritz!OS versions support RSA keys only."
 fi


### PR DESCRIPTION
In addition to RSA keys, current versions of Fritz!OS also support EC keys. It has been confirmed that the EC keys work with version 8.25.

Closes #34